### PR TITLE
fix: title empty string으로 인한 에러 수정

### DIFF
--- a/.github/ISSUE_TEMPLATE/PLANNING.yml
+++ b/.github/ISSUE_TEMPLATE/PLANNING.yml
@@ -1,6 +1,6 @@
 name: 📅 일정 및 계획 작성
 description: 다음 모임에 대한 일정 내용을 정리해요.
-title: ""
+title: "[일정] "
 labels: ["일정", "예정"]
 projects: []
 assignees: ["JengYoung", "BO-LIKE-CHICKEN", "dkmqflx"]


### PR DESCRIPTION
## 관련 이슈

#1, #3, #4, #6

## 내용

커스터마이징을 했는데 나오지 않은 적은 처음이라 당황했지만, 다음 에러문을 통해 원인을 찾았어요!

<img width="691" alt="image" src="https://github.com/user-attachments/assets/c4c74dae-8cb1-44d8-8b05-b8d638568151">

[여기](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms)에서는 `String`도 된다고 했는데... 😭 이런~